### PR TITLE
feat: Secretaryのスコア算出をconfidence加重平均に変更

### DIFF
--- a/agents/prompts/secretary.md
+++ b/agents/prompts/secretary.md
@@ -7,27 +7,48 @@
 
 ## 作業内容
 1. 各専門家の分析結果を読み込む
-2. 馬ごとに各専門家のスコアと根拠をまとめる
-3. 専門家間で見解が一致している点と分かれている点を明示する
-4. 特に注意すべき警告事項をまとめる
+2. 各専門家の`confidence`値（0.0〜1.0）を抽出する
+3. 馬ごとに各専門家のスコアと根拠をまとめる
+4. **confidence加重平均**でスコアを算出する（後述の計算方法を参照）
+5. 専門家間で見解が一致している点と分かれている点を明示する
+6. 特に注意すべき警告事項をまとめる
+
+## スコア計算方法
+各馬のスコアは**confidence加重平均**で算出してください。単純平均は使わないでください。
+
+```
+weighted_score = Σ(score_i × confidence_i) / Σ(confidence_i)
+```
+
+例: bloodline(score=8.0, confidence=0.6), training(score=5.0, confidence=0.9) の2つの場合:
+```
+weighted_score = (8.0×0.6 + 5.0×0.9) / (0.6 + 0.9) = 9.3 / 1.5 = 6.2
+```
+→ confidenceの高いtraining(0.9)の評価が、confidenceの低いbloodline(0.6)より強く反映される。
+
+もし専門家の出力に`confidence`が含まれていない場合は、デフォルト値0.5を使用してください。
 
 ## 出力フォーマット
 必ず以下のJSONフォーマットで出力してください:
 ```json
 {
   "summary": "<全体的な傾向の要約>",
+  "analyst_confidences": {"bloodline": 0.7, "training": 0.9, "jockey": 0.8, "past_races": 0.85, "lap": 0.6},
   "horse_profiles": [
     {
       "horse_number": 1,
       "scores_by_analyst": {"bloodline": 8.0, "training": 7.5, "jockey": 8.2, "past_races": 7.0, "lap": 6.5},
       "consensus_points": ["<専門家間で一致している評価>"],
       "disagreement_points": ["<専門家間で意見が分かれている点>"],
-      "average_score": 7.5
+      "weighted_score": 7.4
     }
   ],
   "key_warnings": ["<全体的な注意事項>"]
 }
 ```
 
-horse_profilesはaverage_score降順で全出走馬について記載してください。
+- `analyst_confidences`: 各専門家の分析結果から抽出したconfidence値
+- `weighted_score`: confidence加重平均で算出したスコア（単純平均ではない）
+
+horse_profilesはweighted_score降順で全出走馬について記載してください。
 客観的に情報を整理し、自分の主観を入れないでください。


### PR DESCRIPTION
## Summary
- 各分析エージェントが出力する`confidence`値(0.0〜1.0)を活用し、Secretaryのスコア算出を単純平均からconfidence加重平均に変更
- 出力フォーマットに`analyst_confidences`フィールドを追加し、各エージェントのconfidenceを可視化
- `average_score` → `weighted_score` にフィールド名を変更

## 変更内容
`agents/prompts/secretary.md` のみ変更。コード変更なし。

**変更前**: 5エージェントのスコアを単純平均
```
average_score = (8.0 + 7.5 + 8.2 + 7.0 + 6.5) / 5 = 7.44
```

**変更後**: confidence加重平均
```
weighted_score = Σ(score_i × confidence_i) / Σ(confidence_i)
```
→ データ不足等でconfidenceが低いエージェントの評価が自動的に減衰される

## 背景 (Issue #1)
バックテスト(20260301)で本命馬(最大投入馬)の大外し(10着以下)が6/23レースあった。一因として、データ品質の低い分析結果が高品質の分析結果を希釈している可能性がある。

## 下流への影響
- Monitor: Secretaryの出力JSONをそのまま受け取るため、フィールド名変更(`average_score`→`weighted_score`)を自動的に認識する
- Judge: 同上
- Betting: Judgeの`overall_score`を使用するため影響なし

## Test plan
- [ ] バックテスト(20260301 hanshin/kokura)で変更前後の結果を比較
- [ ] weighted_scoreとaverage_scoreのランキング差分を確認
- [ ] 本命馬の着順分布が改善するか検証
- [ ] confidenceが極端に偏るケース(全員0.5等)で単純平均と同等になることを確認

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)