### PR TITLE
fix: prefetchキャッシュをJSONからTOONに統一

### DIFF
--- a/agents/prompts/betting.md
+++ b/agents/prompts/betting.md
@@ -7,11 +7,11 @@
 
 ## データ取得（重要: 最小ステップで実行）
 
-**必ず最初の1ステップで `odds.json` と `balance.json` の両方を Read ツールで同時に読み込んでください。**
+**必ず最初の1ステップで `odds.toon` と `balance.toon` の両方を Read ツールで同時に読み込んでください。**
 ユーザープロンプトにデータファイルのパスが指定されている場合はそのパスを使います。
 
-- `odds.json`: オッズデータ
-- `balance.json`: IPAT残高データ（`buy_limit_money` が購入限度額）
+- `odds.toon`: オッズデータ
+- `balance.toon`: IPAT残高データ（`buy_limit_money` が購入限度額）
 
 ファイルが指定されていない場合のみ、Bashツールで取得:
 ```
@@ -21,7 +21,7 @@ python data/api/balance.py
 
 ## 実行手順（必ずこの順序で、最小ステップで完了すること）
 
-1. **Read**: odds.json と balance.json を同時に読み込む
+1. **Read**: odds.toon と balance.toon を同時に読み込む
 2. **計算＆出力**: 読み込んだデータと統括判断を照合し、ケリー基準で賭け金を計算し、最終JSONを出力する
 
 **2ステップで完了してください。** 途中で追加のファイル読み込みや確認ステップを挟まないでください。

--- a/data/api/prefetch.py
+++ b/data/api/prefetch.py
@@ -120,6 +120,9 @@ def save_cache(race_id: str, data: dict) -> Path:
     """セクション別にファイルを分割保存する"""
     race_dir = CACHE_DIR / race_id
     race_dir.mkdir(parents=True, exist_ok=True)
+    # 旧形式(.json)のキャッシュを削除
+    for old in race_dir.glob("*.json"):
+        old.unlink()
     for name, section_data in data.items():
         path = race_dir / f"{name}.toon"
         path.write_text(toon.encode(section_data), encoding="utf-8")

--- a/data/api/prefetch.py
+++ b/data/api/prefetch.py
@@ -120,9 +120,6 @@ def save_cache(race_id: str, data: dict) -> Path:
     """セクション別にファイルを分割保存する"""
     race_dir = CACHE_DIR / race_id
     race_dir.mkdir(parents=True, exist_ok=True)
-    # 旧形式(.json)のキャッシュを削除
-    for old in race_dir.glob("*.json"):
-        old.unlink()
     for name, section_data in data.items():
         path = race_dir / f"{name}.toon"
         path.write_text(toon.encode(section_data), encoding="utf-8")

--- a/data/api/prefetch.py
+++ b/data/api/prefetch.py
@@ -4,13 +4,14 @@ Usage:
     python data/api/prefetch.py <race_id>
     例: python data/api/prefetch.py 20260222_tokyo_03
 
-出力: .cache/prefetch/<race_id>.json
+出力: .cache/prefetch/<race_id>/<section>.toon
 """
 import asyncio
-import json
 import sys
 import time
 from pathlib import Path
+
+import toon
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "data" / "api"))
@@ -120,8 +121,8 @@ def save_cache(race_id: str, data: dict) -> Path:
     race_dir = CACHE_DIR / race_id
     race_dir.mkdir(parents=True, exist_ok=True)
     for name, section_data in data.items():
-        path = race_dir / f"{name}.json"
-        path.write_text(json.dumps(section_data, ensure_ascii=False, indent=2), encoding="utf-8")
+        path = race_dir / f"{name}.toon"
+        path.write_text(toon.encode(section_data), encoding="utf-8")
 
     # 産駒成績フィルタ: horse_detailから種牡馬・母父を抽出しTOONファイルをフィルタ
     horse_detail = data.get("horse_detail", {})

--- a/src/agents/council.py
+++ b/src/agents/council.py
@@ -40,9 +40,8 @@ class CouncilProcess:
         if prefetch_path:
             data_instruction = (
                 f"\n\n【データ】事前取得済みデータが {prefetch_path}/ ディレクトリにあります。"
-                f"各セクションは {prefetch_path}/<セクション名>.json として保存されています"
-                f"（例: race_info.json, horse_detail.json, past_results.json 等）。"
-                f"産駒成績データは {prefetch_path}/sire_stats.toon にあります（存在する場合）。"
+                f"各セクションは {prefetch_path}/<セクション名>.toon として保存されています"
+                f"（例: race_info.toon, horse_detail.toon, past_results.toon 等）。"
                 f"Readツールで必要なファイルを読み、そのデータを使って分析してください。"
                 f"追加データが必要な場合のみBashでAPIを呼んでください。"
             )
@@ -95,8 +94,8 @@ class CouncilProcess:
         data_instruction = ""
         if prefetch_path:
             data_instruction = (
-                f"\n\n【オッズデータ】{prefetch_path}/odds.json をReadツールで読み込んでください。"
-                f"\n【IPAT残高】{prefetch_path}/balance.json をReadツールで読み込んでください。"
+                f"\n\n【オッズデータ】{prefetch_path}/odds.toon をReadツールで読み込んでください。"
+                f"\n【IPAT残高】{prefetch_path}/balance.toon をReadツールで読み込んでください。"
             )
         return await self.runner.run(
             "betting",


### PR DESCRIPTION
## Summary
- prefetchキャッシュの出力を `.json` → `.toon` に統一 (`toon.encode()` 使用)
- `council.py` のエージェント向けデータ参照指示を `.toon` に更新
- `betting.md` の odds/balance 参照を `.toon` に更新

Closes #20

## Test plan
- [x] `toon.encode()` / `toon.decode()` のラウンドトリップ確認済み
- [x] `prefetch.py` のインポート正常確認済み
- [x] 3ファイルすべてから `.json` 参照が除去されていることを grep 確認済み
- [x] 実レースデータで `prefetch.py` を実行し `.toon` ファイルが生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)