### PR TITLE
fix: test_training_stubのキー名不一致とbloodlineのnullスコア定義欠落を修正

### DIFF
--- a/agents/prompts/bloodline.md
+++ b/agents/prompts/bloodline.md
@@ -82,7 +82,7 @@ python data/api/horse_detail.py <race_id>
 - `analyst`: 固定値 `"bloodline"`
 - `race_id`: 入力されたレースID
 - `analysis`: 血統的観点からのレース全体の総合分析（自然言語）
-- `rankings`: 全出走馬のスコア（0.0〜10.0）と根拠をスコア降順で記載
+- `rankings`: 全出走馬のスコア（0.0〜10.0またはnull）と根拠をスコア降順で記載。血統データが不十分な馬は `score: null` とし、末尾に配置する
 - `confidence`: 分析の確信度（0.0〜1.0）。下記の算出基準に従って調整
 - `warnings`: 血統分析上の注意点やリスク要因（該当がなければ空配列）
 

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -41,7 +41,7 @@ def test_training_stub():
         cwd="/home/inoue-d/dev/claude-keiba"
     )
     data = json.loads(result.stdout)
-    assert "horses" in data
+    assert "entries" in data
 
 
 def test_x_search_stub():


### PR DESCRIPTION
## Summary
- `test_training_stub` のアサーションキーを `"horses"` → `"entries"` に修正（training.pyの実APIに合わせる）
- `bloodline.md` のスコア基準に `null` 定義を追加（他4分析エージェントとの統一）

Closes #22
Closes #23

## Test plan
- [x] `pytest tests/test_data_api.py::test_training_stub` PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)